### PR TITLE
Implemented stat subscription renewal and filtered stats to clients

### DIFF
--- a/ackuaria.js
+++ b/ackuaria.js
@@ -55,7 +55,7 @@ N.API.getRooms(function(roomList) {
              streams: [],
              users: [],
              failed: []
-         };      
+         };
       }
    }
 })
@@ -84,22 +84,20 @@ amqper.connect(function() {
              }
           }
        }
-      for (var s in API.sockets) {
-        API.sockets[s].emit('agentsEvent', {
-            agents: API.agents,
-            streams: streams
-        });
-      }
-
+       API.sockets.forEach((currentSocket, currentSocketId) => {
+         currentSocket.emit('agentsEvent', {
+           agents: API.agents,
+           streams: streams
+         });
+       });
     });
   }
   getErizoAgents();
   setInterval(getErizoAgents, 5000);
 });
 
-io.on('connection', function(socket) {
-   API.sockets.push(socket);
-});
+io.on('connection', API.addNewConnection);
+
 
 app.use('/ackuaria', ackuaria_router);
 

--- a/ackuaria_config.js.template
+++ b/ackuaria_config.js.template
@@ -14,7 +14,6 @@ config.rabbit.port = 5672; //default value: 5672
 config.logger = {};
 config.logger.config_file = './log4js_configuration.json'; //default value: "../log4js_configuration.json"
 
-
 /*********************************************************
  DB CONFIGURATION.
  If not used, only real-time data will be provided
@@ -33,6 +32,13 @@ config.nuve = {};
 config.nuve.host = 'http://localhost:3000/'; // default value: 'http://localhost:3000/'
 config.nuve.superserviceID = ''; // default value: ''
 config.nuve.superserviceKey = ''; // default value: ''
+
+/*********************************************************
+ LICODE STATS CONFIGURATION
+**********************************************************/
+config.stats = {};
+config.stats.subscriptionDuration = 60;
+config.stats.subscriptionInterval = 1;
 
 
 /***** END *****/

--- a/common/amqper.js
+++ b/common/amqper.js
@@ -1,14 +1,15 @@
 var sys = require('util');
 var amqp = require('amqp');
 var logger = require('./logger').logger;
-
+var config = require('./../ackuaria_config');
 // Logger
 var log = logger.getLogger("AMQPER");
 
 // Configuration default values
-GLOBAL.config.rabbit = GLOBAL.config.rabbit || {};
-GLOBAL.config.rabbit.host = GLOBAL.config.rabbit.host || 'localhost';
-GLOBAL.config.rabbit.port = GLOBAL.config.rabbit.port || 5672;
+GLOBAL.config = config || {};
+GLOBAL.config.rabbit = config.rabbit || {};
+GLOBAL.config.rabbit.host = config.rabbit.host || 'localhost';
+GLOBAL.config.rabbit.port = config.rabbit.port || 5672;
 
 var TIMEOUT = 5000;
 
@@ -123,7 +124,7 @@ exports.bind_broadcast = function(id, callback) {
 
             q.bind('broadcastExchange', id);
             q.subscribe(function (m){callback(m)});
-            
+
         } catch (err) {
             log.error("Error in exchange ", exchange.name, " - error - ", err);
         }
@@ -136,7 +137,7 @@ exports.bind_broadcast = function(id, callback) {
  */
 exports.broadcast = function(topic, message, callback) {
     var body = {message: message};
-    
+
     if (callback) {
         corrID ++;
         map[corrID] = {};

--- a/common/api.js
+++ b/common/api.js
@@ -8,12 +8,12 @@ var eventsRegistry = require('./mdb/eventsRegistry');
 var statsRegistry = require('./mdb/statsRegistry');
 var sessionsRegistry = require('./mdb/sessionsRegistry');
 var roomsRegistry = require('./mdb/roomsRegistry');
+var amqper = require('./../common/amqper');
 var N = require('./../nuve');
 
 GLOBAL.config = config || {};
 
 
-API.sockets = [];
 
 API.rooms = {};
 API.streams = {};
@@ -22,402 +22,464 @@ API.states = {};
 API.currentRoom;
 API.sessions_active = {};
 API.lastUpdated;
+// key: socketId, value: socket
+API.sockets = new Map();
+// key: streamId, value: {socketIds: Map(socketId : true), interval: fn }
+const statsSubscriptions = new Map();
 
-function isEmpty(obj) {
-    for (var key in obj) {
-        if (obj.hasOwnProperty(key))
-            return false;
-    }
-    return true;
-}
-
-function search(id, myArray) {
-    for (var i=0; i < myArray.length; i++) {
-        if (myArray[i].streamID === id) {
-            return myArray[i];
-        }
-    }
-}
-
-API.api = {
-    event: function(theEvent) {
-        try {
-            theEvent = theEvent.message;
-            log.info("Event:", theEvent);
-            var event = {};
-            switch (theEvent.type) {
-
-                case "publish":
-                    // Memoria local para datos
-                    var agentID = theEvent.agent;
-                    var streamID = theEvent.stream;
-                    var roomID = theEvent.room;
-                    var userID = theEvent.user;
-                    var userName = theEvent.name;
-                    var initTimestamp = theEvent.timestamp;
-
-                    event.streamID = streamID;
-                    event.roomID = roomID;
-                    event.userID = userID;
-                    event.userName = userName;
-
-
-                    if (API.rooms[roomID] === undefined) {
-                        N.API.getRoom(roomID, function(room){
-                            API.rooms[roomID] = {
-                                roomName: JSON.parse(room).name,
-                                data: JSON.parse(room).data,
-                                streams: [streamID],
-                                users: [userID],
-                                failed: []
-                            };
-
-                            var nSession, sessionID, session;
-                            if (!API.sessions_active[roomID]) nSession = 1;
-                            else nSession = API.sessions_active[roomID].nSession + 1;
-                            sessionID = roomID + "_" + nSession;
-                            var roomData = {};
-                            roomData._name = API.rooms[roomID].roomName;
-                            for (var d in API.rooms[roomID].data) {
-                                roomData[d] = API.rooms[roomID].data[d];
-                            }
-
-                            session = {
-                                sessionID: sessionID,
-                                nSession: nSession,
-                                roomID: roomID,
-                                roomData: roomData,
-                                initTimestamp: initTimestamp,
-                                streams: [{streamID: streamID, userID: userID, initPublish: initTimestamp }],
-                                failed: []
-                            }
-                            API.sessions_active[roomID] = session;
-                        })
-
-                    } else {
-
-                        if (API.rooms[roomID].streams.length == 0) {
-                            var nSession, sessionID, session;
-                            if (!API.sessions_active[roomID]) nSession = 1;
-                            else nSession = API.sessions_active[roomID].nSession + 1;
-                            sessionID = roomID + "_" + nSession;
-                            var roomData = {};
-                            roomData._name = API.rooms[roomID].roomName;
-                            for (var d in API.rooms[roomID].data) {
-                                roomData[d] = API.rooms[roomID].data[d];
-                            }
-                            session = {
-                                sessionID: sessionID,
-                                nSession: nSession,
-                                roomID: roomID,
-                                roomData: roomData,
-                                initTimestamp: initTimestamp,
-                                streams: [{streamID: streamID, userID: userID, initPublish: initTimestamp }],
-                                failed: []
-                            }
-                            API.sessions_active[roomID] = session;
-
-                            roomsRegistry.hasRoom(roomID, function(hasRoom){
-                                if (!hasRoom) {
-                                    roomsRegistry.addRoom({
-                                        roomID: roomID,
-                                        roomName: API.rooms[roomID].roomName,
-                                        data: API.rooms[roomID].data
-                                    }, function(saved) {
-                                        log.info('MongoDB: Added room: ', saved);
-                                    })
-                                }
-                            })
-
-                        } else {
-                            var session = API.sessions_active[roomID];
-                            var stream = {
-                                streamID: streamID,
-                                userID: userID,
-                                initPublish: initTimestamp
-                            }
-                            session.streams.push(stream);
-                            API.sessions_active[roomID] = session;
-                        }
-
-                        API.rooms[roomID].streams.push(streamID);
-                        if (API.rooms[roomID].users.indexOf(userID) > -1) {
-                            API.rooms[roomID].users.push(userID);
-                        }
-                    }
-
-                    if (API.users[userID] === undefined) {
-                        API.users[userID] = {
-                            userName: userName,
-                            roomID: roomID,
-                            streams: [streamID],
-                            subscribedTo: []
-                        };
-                    } else {
-                        API.users[userID].streams.push(streamID);
-                    }
-
-                    API.streams[streamID] = {
-                        agentID: agentID,
-                        userID: userID,
-                        roomID: roomID,
-                        userName: userName,
-                        subscribers: []
-                    };
-                    break;
-
-                case "unpublish":
-                    var streamID = theEvent.stream;
-                    var roomID = theEvent.room;
-                    var userID = theEvent.user;
-                    var finalTimestamp = theEvent.timestamp;
-
-                    event.streamID = streamID;
-                    event.roomID = roomID;
-                    event.userID = userID;
-
-                    var session = API.sessions_active[roomID];
-                    if (session !== undefined) {
-                        var stream = search(streamID, session.streams);
-                        stream.finalPublish = finalTimestamp;
-                    }
-
-                    if (API.rooms[roomID] !== undefined) {
-                        var indexRoom = API.rooms[roomID].streams.indexOf(streamID);
-                        if (indexRoom > -1) API.rooms[roomID].streams.splice(indexRoom, 1);
-                        if (API.rooms[roomID].streams.length == 0) {
-                            // If room is empty the session is over
-                            if (session !== undefined) {
-                                session.finalTimestamp = finalTimestamp;
-                                API.sessions_active[roomID] = session;
-                                if (config.ackuaria.useDB) {
-                                    sessionsRegistry.addSession(session, function(saved, error) {
-                                         if (error) log.warn('MongoDB: Error adding session ', error);
-                                         if (saved) log.info('MongoDB: Added session: ', saved);
-                                    })
-                                }
-                            }
-                        }
-                    }
-
-                    if (API.users[userID] !== undefined) {
-                        var indexUser = API.users[userID].streams.indexOf(streamID);
-                        if (indexUser > -1) API.users[userID].streams.splice(indexUser, 1);
-                    }
-
-                    if (API.streams[streamID] !== undefined) {
-                        var subscribers = API.streams[streamID].subscribers;
-                        for (var s in subscribers) {
-                            if (API.users[subscribers[s]]) {
-                                var indexSub = API.users[subscribers[s]].subscribedTo.indexOf(streamID);
-                                if (indexSub > -1) API.users[subscribers[s]].subscribedTo.splice(indexSub, 1);
-                            }
-                        }
-                    }
-
-                    delete API.streams[streamID];
-
-                    delete API.states[streamID];
-
-                    API.sessions_active[roomID] = session;
-
-                    break;
-
-                case "subscribe":
-                    var streamID = theEvent.stream;
-                    var userID = theEvent.user;
-                    var roomID = theEvent.room;
-                    var userName = theEvent.name;
-
-                    event.streamID = streamID;
-                    event.roomID = roomID;
-                    event.userID = userID;
-                    event.userName = userName;
-
-                    API.streams[streamID].subscribers.push(userID);
-
-                    if (API.users[userID] === undefined) {
-                        API.users[userID] = {
-                            userName: userName,
-                            roomID: roomID,
-                            streams: [],
-                            subscribedTo: [streamID]
-                        }
-                    } else {
-                        API.users[userID].subscribedTo.push(streamID);
-                    }
-
-
-                    roomsRegistry.hasRoom(roomID, function(hasRoom){
-                        if (!hasRoom) {
-                            roomsRegistry.addRoom({
-                                roomID: roomID,
-                                roomName: API.rooms[roomID].roomName,
-                                data: API.rooms[roomID].data
-                            }, function(saved) {
-                                log.info('MongoDB: Added room: ', saved);
-                            })
-                        }
-                    })
-                    break;
-
-                case "unsubscribe":
-                    var streamID = theEvent.stream;
-                    var userID = theEvent.user;
-                    var roomID = theEvent.room;
-
-                    event.streamID = streamID;
-                    event.roomID = roomID;
-                    event.userID = userID;
-
-                    if (API.streams[streamID] !== undefined) {
-                        var indexStream = API.streams[streamID].subscribers.indexOf(userID);
-                        if (indexStream > -1) API.streams[streamID].subscribers.splice(indexStream, 1);
-                    }
-
-                    if (API.users[userID] !== undefined) {
-                        var indexUser = API.users[userID].subscribedTo.indexOf(streamID);
-                        if (indexUser > -1) API.users[userID].subscribedTo.splice(indexUser, 1);
-                        if (API.users[userID].streams.length == 0 && API.users[userID].subscribedTo.length == 0) {
-                            delete API.users[userID];
-                            for (var stream in API.streams) {
-                                var indexStream = API.streams[stream].subscribers.indexOf(userID);
-                                if (indexStream > -1) API.streams[stream].subscribers.splice(indexStream, 1);
-
-                                delete API.states[stream].subscribers[userID];
-                            }
-                        }
-                    }
-                    break;
-
-                case "user_disconnection":
-                    var roomID = theEvent.room;
-                    var userID = theEvent.user;
-
-                    event.roomID = roomID;
-                    event.subID = userID;
-                    
-                    for (var streamID in API.streams) {
-                        var indexStream = API.streams[streamID].subscribers.indexOf(userID);
-                        if (indexStream > -1) API.streams[streamID].subscribers.splice(indexStream, 1);
-                        
-                        delete API.states[streamID].subscribers[userID];
-
-                        if (API.streams[streamID].userID == userID){
-                            delete API.streams[streamID];
-
-                            if (API.rooms[roomID] !== undefined) {
-                                var indexStream = API.rooms[roomID].streams.indexOf(streamID);
-                                if (indexStream > -1) API.rooms[roomID].streams.splice(indexStream, 1);
-                            }
-
-                            delete API.states[streamID];
-                        }
-                    }
-                    
-                    delete API.users[userID];
-
-                    break;
-
-                case "connection_status":
-                    var streamID = theEvent.pub;
-                    var subID = theEvent.subs;
-                    var state = theEvent.status;
-                    var roomID = API.streams[streamID].roomID;
-
-                    event.type = "connection_status";
-                    event.streamID = streamID;
-                    event.subID = subID;
-                    event.state = state;
-                    event.roomID = roomID;
-
-                    if (!subID) {
-                        if (!API.states[streamID]) {
-                            API.states[streamID] = {
-                                state: state,
-                                subscribers: {}
-                            };
-                        } else {
-                            API.states[streamID].state = state;
-                        }
-                        subID = API.streams[streamID].userID;
-
-                    } else {
-                        API.states[streamID].subscribers[subID] = state;
-                    }
-
-
-                    break;
-
-                case "failed":
-                    var roomID = theEvent.room;
-                    var userID = theEvent.user;
-                    var userName = API.users[userID].userName;
-                    var streamID = theEvent.stream;
-                    var sdp = theEvent.sdp;
-
-                    event.type = "failed";
-                    event.streamID = streamID;
-                    event.subID = subID;
-                    event.roomID = roomID;
-                    event.sdp = sdp;
-                    API.sessions_active[roomID].failed.push({streamID: streamID, userID: userID, userName: userName, sdp:sdp});
-                    API.rooms[roomID].failed.push({streamID: streamID, userID: userID, userName: userName, sdp:sdp});
-
-                    var indexRoom = API.rooms[roomID].streams.indexOf(streamID);
-                    if (indexRoom > -1) API.rooms[roomID].streams.splice(indexRoom, 1);
-                    break;
-                default:
-                    break;
-            }
-            if (API.currentRoom == event.roomID || API.currentRoom == "") {
-                API.send_event_to_clients(event, API.rooms, API.streams, API.users, API.states);
-            }
-            if (config.ackuaria.useDB) {        
-                eventsRegistry.addEvent(theEvent, function(saved, error) {
-                    // if (saved) log.info(saved);
-                    if (error) log.error(error);
-                })
-            }
-
-            //}
-
-        } catch (err) {
-            console.log("Error receiving event:", err);
-        }
-    },
-    stats: function(theStats) {
-        // log.info('Stat: ', theStats);
-        theStats = theStats.message;
-        try {
-            API.send_stats_to_clients(theStats);
-
-        } catch (err) {
-            log.error("Error receiving stat", err);
-        }
-    }
+const isEmpty = (obj) => {
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key))
+    return false;
+  }
+  return true;
 };
 
-API.send_event_to_clients = function(event, rooms, streams, users, states) {
-    for (var s in API.sockets) {
-        API.sockets[s].emit('newEvent', {
+const search = (id, myArray) => {
+  for (var i=0; i < myArray.length; i++) {
+    if (myArray[i].streamID === id) {
+      return myArray[i];
+    }
+  }
+};
+
+const sendStatsToClients = (event) => {
+    event.timestamp = (new Date()).getTime();
+    statsSubscriptions.forEach((subscription, streamID) => {
+      subscription.socketIds.forEach((value, socketId) => {
+        let subscribedSocket = API.sockets.get(socketId)
+        if (subscribedSocket) {
+          subscribedSocket.emit('newStats', {
+            event: event,
+          });
+        }
+      });
+    });
+};
+
+const subscribeToLicodeStatsStream = (streamId, duration, interval) => {
+  log.debug(`Subscribing to licode stat stream id ${streamId} for ${duration}s with interval ${interval}s`);
+  return new Promise((resolve, reject) => {
+    amqper.broadcast('ErizoJS', {method: 'subscribeToStats', args: [streamId, duration, interval]},
+    (response) => {
+        resolve(response);
+    })
+  });
+};
+
+const subscribeClientToStats = (socketId, streamId) => {
+  removeSubscriptionsforSocket(socketId);
+  if (statsSubscriptions.has(streamId)){
+    log.debug('Adding socket', socketId, ' to subscription')
+    statsSubscriptions.get(streamId).socketIds[socketId] = true;
+  } else {
+    log.debug('Adding new subscription to ' + streamId + ' form ' + socketId);
+    const subscribeToThisStream = () => {
+      log.debug('Renewing subscription to ' +  streamId);
+      subscribeToLicodeStatsStream(streamId,config.stats.subscriptionDuration, config.stats.subscriptionInterva).then((result) => {
+        log.debug(`Stats subscription to ${streamId}, result: ${result}`);
+      });
+    };
+    subscribeToThisStream();
+    const subscription = {
+      socketIds : new Map(),
+      interval : setInterval(()=> {
+        subscribeToThisStream();
+      }, (config.stats.subscriptionDuration - 2) * 1000) // a little margin for renewal
+    };
+    subscription.socketIds.set(socketId, true);
+    statsSubscriptions.set(streamId, subscription);
+  }
+};
+
+const removeSubscriptionsforSocket = (socketId) => {
+  log.debug('Removing subscriptions for ' + socketId);
+  statsSubscriptions.forEach((subscription, streamId) => {
+    log.debug('Subscription ', streamId, ' has', subscription.socketIds.size, 'listening');
+    subscription.socketIds.delete(socketId);
+    if (subscription.socketIds.size === 0 ){
+      clearInterval(subscription.interval);
+      subscribeToLicodeStatsStream(streamId, 0, 0).then((result)=>{
+        log.debug(`Removed subscription to ${streamId}: result ${result}`);
+        statsSubscriptions.delete(streamId);
+      });
+    }
+  });
+};
+
+const removeConnection = (socketId) => {
+  log.debug('Removing socketId ' + socketId);
+  removeSubscriptionsforSocket(socketId);
+  API.sockets.delete(socketId);
+};
+
+const sendEventToClients = function(event, rooms, streams, users, states) {
+  API.sockets.forEach((currentSocket, currentSocketId) => {
+        currentSocket.emit('newEvent', {
             event: event,
             rooms: rooms,
             streams: streams,
             users: users,
             states: states
         });
-    }
-}
+    });
+};
 
-API.send_stats_to_clients = function(event) {
-    event.timestamp = (new Date()).getTime();
-    for (var s in API.sockets) {
-        API.sockets[s].emit('newStats', {
-            event: event
-        });
+API.api = {};
+API.api.event = function(theEvent) {
+  try {
+    theEvent = theEvent.message;
+    log.info("Event:", theEvent);
+    var event = {};
+    switch (theEvent.type) {
+
+      case "publish":
+        var agentID = theEvent.agent;
+        var streamID = theEvent.stream;
+        var roomID = theEvent.room;
+        var userID = theEvent.user;
+        var userName = theEvent.name;
+        var initTimestamp = theEvent.timestamp;
+
+        event.streamID = streamID;
+        event.roomID = roomID;
+        event.userID = userID;
+        event.userName = userName;
+
+
+        if (API.rooms[roomID] === undefined) {
+          N.API.getRoom(roomID, function(room){
+            API.rooms[roomID] = {
+              roomName: JSON.parse(room).name,
+              data: JSON.parse(room).data,
+              streams: [streamID],
+              users: [userID],
+              failed: []
+            };
+
+            var nSession, sessionID, session;
+            if (!API.sessions_active[roomID]) nSession = 1;
+            else nSession = API.sessions_active[roomID].nSession + 1;
+            sessionID = roomID + "_" + nSession;
+            var roomData = {};
+            roomData._name = API.rooms[roomID].roomName;
+            for (var d in API.rooms[roomID].data) {
+              roomData[d] = API.rooms[roomID].data[d];
+            }
+
+            session = {
+              sessionID: sessionID,
+              nSession: nSession,
+              roomID: roomID,
+              roomData: roomData,
+              initTimestamp: initTimestamp,
+              streams: [{streamID: streamID, userID: userID, initPublish: initTimestamp }],
+              failed: []
+            }
+            API.sessions_active[roomID] = session;
+          })
+
+        } else {
+
+          if (API.rooms[roomID].streams.length == 0) {
+            var nSession, sessionID, session;
+            if (!API.sessions_active[roomID]) nSession = 1;
+            else nSession = API.sessions_active[roomID].nSession + 1;
+            sessionID = roomID + "_" + nSession;
+            var roomData = {};
+            roomData._name = API.rooms[roomID].roomName;
+            for (var d in API.rooms[roomID].data) {
+              roomData[d] = API.rooms[roomID].data[d];
+            }
+            session = {
+              sessionID: sessionID,
+              nSession: nSession,
+              roomID: roomID,
+              roomData: roomData,
+              initTimestamp: initTimestamp,
+              streams: [{streamID: streamID, userID: userID, initPublish: initTimestamp }],
+              failed: []
+            }
+            API.sessions_active[roomID] = session;
+
+            roomsRegistry.hasRoom(roomID, function(hasRoom){
+              if (!hasRoom) {
+                roomsRegistry.addRoom({
+                  roomID: roomID,
+                  roomName: API.rooms[roomID].roomName,
+                  data: API.rooms[roomID].data
+                }, function(saved) {
+                  log.info('MongoDB: Added room: ', saved);
+                })
+              }
+            })
+
+          } else {
+            var session = API.sessions_active[roomID];
+            var stream = {
+              streamID: streamID,
+              userID: userID,
+              initPublish: initTimestamp
+            }
+            session.streams.push(stream);
+            API.sessions_active[roomID] = session;
+          }
+
+          API.rooms[roomID].streams.push(streamID);
+          if (API.rooms[roomID].users.indexOf(userID) > -1) {
+            API.rooms[roomID].users.push(userID);
+          }
+        }
+
+        if (API.users[userID] === undefined) {
+          API.users[userID] = {
+            userName: userName,
+            roomID: roomID,
+            streams: [streamID],
+            subscribedTo: []
+          };
+        } else {
+          API.users[userID].streams.push(streamID);
+        }
+
+        API.streams[streamID] = {
+          agentID: agentID,
+          userID: userID,
+          roomID: roomID,
+          userName: userName,
+          subscribers: []
+        };
+        break;
+
+      case "unpublish":
+        var streamID = theEvent.stream;
+        var roomID = theEvent.room;
+        var userID = theEvent.user;
+        var finalTimestamp = theEvent.timestamp;
+
+        event.streamID = streamID;
+        event.roomID = roomID;
+        event.userID = userID;
+
+        var session = API.sessions_active[roomID];
+        if (session !== undefined) {
+          var stream = search(streamID, session.streams);
+          stream.finalPublish = finalTimestamp;
+        }
+
+        if (API.rooms[roomID] !== undefined) {
+          var indexRoom = API.rooms[roomID].streams.indexOf(streamID);
+          if (indexRoom > -1) API.rooms[roomID].streams.splice(indexRoom, 1);
+          if (API.rooms[roomID].streams.length == 0) {
+            // If room is empty the session is over
+            if (session !== undefined) {
+              session.finalTimestamp = finalTimestamp;
+              API.sessions_active[roomID] = session;
+              if (config.ackuaria.useDB) {
+                sessionsRegistry.addSession(session, function(saved, error) {
+                  if (error) log.warn('MongoDB: Error adding session ', error);
+                  if (saved) log.info('MongoDB: Added session: ', saved);
+                })
+              }
+            }
+          }
+        }
+
+        if (API.users[userID] !== undefined) {
+          var indexUser = API.users[userID].streams.indexOf(streamID);
+          if (indexUser > -1) API.users[userID].streams.splice(indexUser, 1);
+        }
+
+        if (API.streams[streamID] !== undefined) {
+          var subscribers = API.streams[streamID].subscribers;
+          for (var s in subscribers) {
+            if (API.users[subscribers[s]]) {
+              var indexSub = API.users[subscribers[s]].subscribedTo.indexOf(streamID);
+              if (indexSub > -1) API.users[subscribers[s]].subscribedTo.splice(indexSub, 1);
+            }
+          }
+        }
+
+        delete API.streams[streamID];
+
+        delete API.states[streamID];
+
+        API.sessions_active[roomID] = session;
+        break;
+
+      case "subscribe":
+        var streamID = theEvent.stream;
+        var userID = theEvent.user;
+        var roomID = theEvent.room;
+        var userName = theEvent.name;
+
+        event.streamID = streamID;
+        event.roomID = roomID;
+        event.userID = userID;
+        event.userName = userName;
+
+        API.streams[streamID].subscribers.push(userID);
+
+        if (API.users[userID] === undefined) {
+          API.users[userID] = {
+            userName: userName,
+            roomID: roomID,
+            streams: [],
+            subscribedTo: [streamID]
+          }
+        } else {
+          API.users[userID].subscribedTo.push(streamID);
+        }
+
+
+        roomsRegistry.hasRoom(roomID, function(hasRoom){
+          if (!hasRoom) {
+            roomsRegistry.addRoom({
+              roomID: roomID,
+              roomName: API.rooms[roomID].roomName,
+              data: API.rooms[roomID].data
+            }, function(saved) {
+              log.info('MongoDB: Added room: ', saved);
+            })
+          }
+        })
+        break;
+
+      case "unsubscribe":
+        var streamID = theEvent.stream;
+        var userID = theEvent.user;
+        var roomID = theEvent.room;
+
+        event.streamID = streamID;
+        event.roomID = roomID;
+        event.userID = userID;
+
+        if (API.streams[streamID] !== undefined) {
+          var indexStream = API.streams[streamID].subscribers.indexOf(userID);
+          if (indexStream > -1) API.streams[streamID].subscribers.splice(indexStream, 1);
+        }
+
+        if (API.users[userID] !== undefined) {
+          var indexUser = API.users[userID].subscribedTo.indexOf(streamID);
+          if (indexUser > -1) API.users[userID].subscribedTo.splice(indexUser, 1);
+          if (API.users[userID].streams.length == 0 && API.users[userID].subscribedTo.length == 0) {
+            delete API.users[userID];
+            for (var stream in API.streams) {
+              var indexStream = API.streams[stream].subscribers.indexOf(userID);
+              if (indexStream > -1) API.streams[stream].subscribers.splice(indexStream, 1);
+
+              delete API.states[stream].subscribers[userID];
+            }
+          }
+        }
+        break;
+
+      case "user_disconnection":
+        var roomID = theEvent.room;
+        var userID = theEvent.user;
+
+        event.roomID = roomID;
+        event.subID = userID;
+
+        for (var streamID in API.streams) {
+          var indexStream = API.streams[streamID].subscribers.indexOf(userID);
+          if (indexStream > -1) API.streams[streamID].subscribers.splice(indexStream, 1);
+
+          delete API.states[streamID].subscribers[userID];
+
+          if (API.streams[streamID].userID == userID){
+            delete API.streams[streamID];
+
+            if (API.rooms[roomID] !== undefined) {
+              var indexStream = API.rooms[roomID].streams.indexOf(streamID);
+              if (indexStream > -1) API.rooms[roomID].streams.splice(indexStream, 1);
+            }
+
+            delete API.states[streamID];
+          }
+        }
+
+        delete API.users[userID];
+        break;
+
+      case "connection_status":
+        var streamID = theEvent.pub;
+        var subID = theEvent.subs;
+        var state = theEvent.status;
+        var roomID = API.streams[streamID].roomID;
+
+        event.type = "connection_status";
+        event.streamID = streamID;
+        event.subID = subID;
+        event.state = state;
+        event.roomID = roomID;
+
+        if (!subID) {
+          if (!API.states[streamID]) {
+            API.states[streamID] = {
+              state: state,
+              subscribers: {}
+            };
+          } else {
+            API.states[streamID].state = state;
+          }
+          subID = API.streams[streamID].userID;
+
+        } else {
+          API.states[streamID].subscribers[subID] = state;
+        }
+        break;
+
+      case "failed":
+        var roomID = theEvent.room;
+        var userID = theEvent.user;
+        var userName = API.users[userID].userName;
+        var streamID = theEvent.stream;
+        var sdp = theEvent.sdp;
+
+        event.type = "failed";
+        event.streamID = streamID;
+        event.subID = subID;
+        event.roomID = roomID;
+        event.sdp = sdp;
+        API.sessions_active[roomID].failed.push({streamID: streamID, userID: userID, userName: userName, sdp:sdp});
+        API.rooms[roomID].failed.push({streamID: streamID, userID: userID, userName: userName, sdp:sdp});
+
+        var indexRoom = API.rooms[roomID].streams.indexOf(streamID);
+        if (indexRoom > -1) API.rooms[roomID].streams.splice(indexRoom, 1);
+        break;
+      default:
+        break;
     }
-}
+    if (API.currentRoom == event.roomID || API.currentRoom == "") {
+      sendEventToClients(event, API.rooms, API.streams, API.users, API.states);
+    }
+    if (config.ackuaria.useDB) {
+      eventsRegistry.addEvent(theEvent, function(saved, error) {
+        if (error) log.error(error);
+      })
+    }
+  } catch (err) {
+    log.error("Error receiving event:", err);
+  }
+};
+
+API.api.stats = function(theStats) {
+  theStats = theStats.message;
+  try {
+    sendStatsToClients(theStats);
+
+  } catch (err) {
+    log.error("Error receiving stat", err);
+  }
+};
+
+API.addNewConnection = (socket) => {
+  log.debug('New socket connected ' + socket.id);
+  API.sockets.set(socket.id, socket);
+  socket.on('disconnect', removeConnection.bind(null, socket.id));
+  socket.on('subscribe_to_stats', subscribeClientToStats.bind(null, socket.id));
+};
 
 var module = module || {};
 module.exports = API;

--- a/controllers/ackuaria_controller.js
+++ b/controllers/ackuaria_controller.js
@@ -3,7 +3,6 @@ var API = require('./../common/api');
 var N = require('./../nuve');
 var config = require('./../ackuaria_config');
 var api_controller = require('./api_controller');
-var amqper = require('./../common/amqper');
 
 exports.updateRooms = function(req, res, next) {
    var date = new Date().getTime();
@@ -32,7 +31,7 @@ exports.updateRooms = function(req, res, next) {
          console.log("Nuve called: Updated Room List");
 
          next();
-      })   
+      })
    } else {
       console.log("Too soon for calling Nuve again.");
       next();
@@ -96,7 +95,7 @@ exports.loadSubscribers = function(req, res) {
 
    if (API.rooms[roomID]) var roomName = API.rooms[roomID].roomName;
    else var roomName = "Not found";
-   
+
    var streamsInRoom = {};
    for (var s in API.streams){
       if (room.streams.indexOf(parseInt(s)) > -1) {
@@ -110,10 +109,6 @@ exports.loadSubscribers = function(req, res) {
          statesInRoom[s] = API.states[s];
       }
    }
-
-   amqper.broadcast('ErizoJS', {method: 'subscribeToStats', args: [streamID, 60, 1]}, function(resp){
-      console.log('Stats subscription result to ', streamID, ':', resp);
-   });
 
    res.render('subscribers', {
       view: "subscribers",

--- a/public/javascripts/subscribers.js
+++ b/public/javascripts/subscribers.js
@@ -7,8 +7,7 @@ var ssrcs = {};
 var lastTimestamp, lastBytesAudio, lastBytesVideo;
 
 $(document).ready(function(){
-
-
+    socket.emit('subscribe_to_stats', streamID);
     socket.on('newEvent', function(evt) {
         var event = evt.event;
         rooms = evt.rooms;
@@ -28,7 +27,7 @@ $(document).ready(function(){
              states[s] = totalStates[s];
             }
         }
-        users = evt.users; 
+        users = evt.users;
 
         $('#others').html("");
         $('#selected').html("");
@@ -153,7 +152,7 @@ $(document).ready(function(){
             paintSubscribersList();
             search();
         }
-        $(this).addClass('active');  
+        $(this).addClass('active');
         $(this).addClass('btn-primary');
         $(this).removeClass('btn-default');
 
@@ -169,7 +168,7 @@ $(document).ready(function(){
             paintSubscribersGrid();
             search();
         }
-        $(this).addClass('active');  
+        $(this).addClass('active');
         $(this).addClass('btn-primary');
         $(this).removeClass('btn-default');
 
@@ -183,7 +182,7 @@ $(document).ready(function(){
             $( ".audioChart" ).hide();
             $( ".videoChart" ).show();
         }
-        $(this).addClass('active');  
+        $(this).addClass('active');
         $(this).addClass('btn-primary');
         $(this).removeClass('btn-default');
 
@@ -201,7 +200,7 @@ $(document).ready(function(){
             $( ".videoChart" ).hide();
             $( ".audioChart" ).show();
         }
-        $(this).addClass('active');  
+        $(this).addClass('active');
         $(this).addClass('btn-primary');
         $(this).removeClass('btn-default');
 
@@ -219,7 +218,7 @@ $(document).ready(function(){
             $( ".audioChart" ).show();
             $( ".videoChart" ).show();
         }
-        $(this).addClass('active');  
+        $(this).addClass('active');
         $(this).addClass('btn-primary');
         $(this).removeClass('btn-default');
 
@@ -241,7 +240,7 @@ $(document).ready(function(){
             $( "#videoCol" ).show();
 
         }
-        $(this).addClass('active');  
+        $(this).addClass('active');
         $(this).addClass('btn-primary');
         $(this).removeClass('btn-default');
 
@@ -263,7 +262,7 @@ $(document).ready(function(){
             $( "#audioCol" ).show();
 
         }
-        $(this).addClass('active');  
+        $(this).addClass('active');
         $(this).addClass('btn-primary');
         $(this).removeClass('btn-default');
 
@@ -285,7 +284,7 @@ $(document).ready(function(){
             $( "#audioCol" ).show();
 
         }
-        $(this).addClass('active');  
+        $(this).addClass('active');
         $(this).addClass('btn-primary');
         $(this).removeClass('btn-default');
 
@@ -312,7 +311,7 @@ $(document).ready(function(){
                 color = "orange";
                 break;
         }
-        return color; 
+        return color;
     }
 
     var updateModalState = function(subID) {
@@ -462,7 +461,7 @@ $(document).ready(function(){
         }
         Sortable.init()
 
-    }   
+    }
 
     var createNewSubscriberGrid = function(userID, userName, state){
         var color = stateToColor(state);
@@ -527,7 +526,7 @@ $(document).ready(function(){
 
     var updateStatePublisher = function() {
         var state;
-        if (states[streamID]) state = states[streamID].state;    
+        if (states[streamID]) state = states[streamID].state;
 
         var color = stateToColor(state);
 


### PR DESCRIPTION
Stat subscriptions to ErizoJS are now automatically renewed as long as there is at least one client in a view that makes use of them.
Right now, clients can only be subscribed to one stream and will automatically be unsubscribed when they subscribe to another (or when they close the websocket). This is not important right now as the websocket connection is refreshed every time a different view is selected. However, it will be useful if we ever transform ackuaria into a SPA.

As a bonus, stats are now not broadcasted to all websockets., but selectively sent to only the clients subscribed.

Bonus 2: fixed indentation and used ES6 in `api.js` to slowly start modernizing ackuaria #