### PR TITLE
Fixed a bug that did't allow simultaneous clients in different rooms

### DIFF
--- a/common/api.js
+++ b/common/api.js
@@ -113,7 +113,6 @@ const removeConnection = (socketId) => {
 };
 
 function getParameterByName(name, url) {
-    if (!url) url = window.location.href;
     name = name.replace(/[\[\]]/g, "\\$&");
     var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
         results = regex.exec(url);

--- a/common/api.js
+++ b/common/api.js
@@ -19,7 +19,6 @@ API.rooms = {};
 API.streams = {};
 API.users = {};
 API.states = {};
-API.currentRoom;
 API.sessions_active = {};
 API.lastUpdated;
 // key: socketId, value: socket
@@ -113,16 +112,29 @@ const removeConnection = (socketId) => {
   API.sockets.delete(socketId);
 };
 
+function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return '';
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+
 const sendEventToClients = function(event, rooms, streams, users, states) {
   API.sockets.forEach((currentSocket, currentSocketId) => {
-        currentSocket.emit('newEvent', {
-            event: event,
-            rooms: rooms,
-            streams: streams,
-            users: users,
-            states: states
-        });
-    });
+    var clientCurrentRoom = getParameterByName('room_id', currentSocket.handshake.headers.referer);   
+    if (clientCurrentRoom == event.roomID || clientCurrentRoom == '') {
+      currentSocket.emit('newEvent', {
+        event: event,
+        rooms: rooms,
+        streams: streams,
+        users: users,
+        states: states
+      });
+    }
+  });
 };
 
 API.api = {};
@@ -454,9 +466,7 @@ API.api.event = function(theEvent) {
       default:
         break;
     }
-    if (API.currentRoom == event.roomID || API.currentRoom == "") {
-      sendEventToClients(event, API.rooms, API.streams, API.users, API.states);
-    }
+    sendEventToClients(event, API.rooms, API.streams, API.users, API.states);
     if (config.ackuaria.useDB) {
       eventsRegistry.addEvent(theEvent, function(saved, error) {
         if (error) log.error(error);

--- a/controllers/ackuaria_controller.js
+++ b/controllers/ackuaria_controller.js
@@ -39,7 +39,6 @@ exports.updateRooms = function(req, res, next) {
 }
 
 exports.loadRooms = function(req, res) {
-   API.currentRoom = "";
    res.render('rooms', {
       view: "rooms",
       rooms: API.rooms
@@ -49,7 +48,6 @@ exports.loadRooms = function(req, res) {
 exports.loadPublishers = function(req, res) {
 	var roomID = req.query.room_id;
    var fails = req.query.fails;
-   API.currentRoom = roomID;
    var room = API.rooms[roomID];
 
    if (API.rooms[roomID]) var roomName = API.rooms[roomID].roomName;
@@ -88,8 +86,7 @@ exports.loadSubscribers = function(req, res) {
    var streamID = req.query.pub_id;
    var roomID = req.query.room_id;
    var room = API.rooms[roomID];
-
-   API.currentRoom = roomID;
+   
    if (API.streams[streamID])  var userName = API.streams[streamID].userName;
    else var userName = "Publisher not found";
 


### PR DESCRIPTION
A global variable `API.currentRoom` did't allow multiple clients connected at the same time and visualizing different rooms. Getting the room from the url (given by socket.io referer) allows this keeping the same behavior of not sending every event to every client. 