### PR TITLE
Run search every time we update a table

### DIFF
--- a/public/javascripts/publishers.js
+++ b/public/javascripts/publishers.js
@@ -83,7 +83,6 @@ $(document).ready(function(){
         if (!$(this).hasClass("active")){
             view_type = "list";
             paintPublishersList();
-            search();
         }
         $(this).addClass('active');
         $(this).addClass('btn-primary');
@@ -104,7 +103,6 @@ $(document).ready(function(){
         if (!$(this).hasClass("active")){
             view_type = "grid";
             paintPublishersGrid();
-            search();
         }
         $(this).addClass('active');
         $(this).addClass('btn-primary');
@@ -216,7 +214,7 @@ var paintPublishersGrid = function() {
         }
         updateAlerts();
     }
-
+    search();
 }
 
 var paintPublishersList = function() {
@@ -240,6 +238,7 @@ var paintPublishersList = function() {
 
         Sortable.init()
     }
+    search();
 }
 
 
@@ -265,6 +264,7 @@ var paintPublishersFails = function() {
             $('#publishers').html('<div class="alert alert-danger" role="alert"><strong>Yay! There are no failed streams in this room</strong></div>')
         }
     }
+    search();
 }
 
 var createNewPublisherGrid = function(roomID, streamID, nSubscribers, userName, state){

--- a/public/javascripts/rooms.js
+++ b/public/javascripts/rooms.js
@@ -52,7 +52,6 @@ $(document).ready(function(){
         if (!$(this).hasClass("active")){
             show_grid = false;
             paintRoomsList();
-            search();
         }
         $(this).addClass('active');
         $(this).addClass('btn-primary');
@@ -67,7 +66,6 @@ $(document).ready(function(){
         if (!$(this).hasClass("active")){
             show_grid = true;
             paintRoomsGrid();
-            search();
         }
         $(this).addClass('active');
         $(this).addClass('btn-primary');
@@ -107,6 +105,7 @@ var paintRoomsGrid = function(){
     if (nRooms == 0) {
         $('#rooms').html('<div class="alert alert-danger" role="alert"><strong>Oops! There are no rooms created</strong></div>')
     }
+    search();
 };
 
 var paintRoomsList = function(){
@@ -130,6 +129,7 @@ var paintRoomsList = function(){
         $('#rooms').html('<div class="alert alert-danger" role="alert"><strong>Oops! There are no rooms created</strong></div>')
     }
     Sortable.init()
+    search();
 };
 
 var createNewRoomGrid = function(roomID, nStreams, roomName){

--- a/public/javascripts/subscribers.js
+++ b/public/javascripts/subscribers.js
@@ -173,7 +173,6 @@ $(document).ready(function(){
         if (!$(this).hasClass("active")){
             show_grid = false;
             paintSubscribersList();
-            search();
         }
         $(this).addClass('active');
         $(this).addClass('btn-primary');
@@ -189,7 +188,6 @@ $(document).ready(function(){
         if (!$(this).hasClass("active")){
             show_grid = true;
             paintSubscribersGrid();
-            search();
         }
         $(this).addClass('active');
         $(this).addClass('btn-primary');
@@ -463,6 +461,7 @@ $(document).ready(function(){
             updateNamePublisher("Publisher not found");
             updateNSubscribers(0);
         }
+        search();
     }
 
     var paintSubscribersList = function() {
@@ -483,8 +482,8 @@ $(document).ready(function(){
             updateNamePublisher("Publisher not found");
             updateNSubscribers(0);
         }
-        Sortable.init()
-
+        Sortable.init();
+        search();
     }
 
     var createNewSubscriberGrid = function(userID, userName, state){


### PR DESCRIPTION
Receiving new events would invalidate the current search, this PR fixes that.

`search()` is now consistently called whenever a table is updated for publishers, subscribers and rooms.