### PR TITLE
Update version of amqp

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "amqp": "0.2.0",
+    "amqp": "0.2.6",
     "body-parser": "~1.8.1",
     "cookie-parser": "~1.3.3",
     "debug": "~2.0.0",


### PR DESCRIPTION
Previous version doesn’t work with latest rabbitmq-server 3.7.5